### PR TITLE
Add debug library

### DIFF
--- a/Debug/usage.debug.lua
+++ b/Debug/usage.debug.lua
@@ -1,0 +1,17 @@
+-- How to use the `user.debug` library
+
+-- Add this constant to your script, to determine whether debug mode is on or off
+local DEBUG = true -- Set to false if you don't want debug messages to log
+
+-- Require the script
+require 'user.debug'
+
+-- Init debug class -- Uses the constant at the top of the script to determine debug mode
+local Debug = DebugLib:new(DEBUG)
+
+-- Write a log message if `DEBUG` is true
+Debug:log("Debug is true. Send message to log")
+
+-- Write a log message if `DEBUG` is true, AND a condition is true
+Debug:logIf(true, "Debug is true, and condition is true. Send message to log")
+Debug:logIf(false, "Debug is true, but condition is not. Do NOT send message to log")

--- a/Debug/user.debug.lua
+++ b/Debug/user.debug.lua
@@ -1,0 +1,46 @@
+--[[
+ * Author: Alexander Volle <postmaster@avolle.com>
+ * Created: 2023.03.31
+ * 
+ * Debug class for writing to log when debug is activated.
+ * Removes the need for doing conditionals at every debug log message
+ *
+]]
+
+DebugLib = {}
+
+--[[
+ * Constructor method
+ * 
+ * @var boolean on - Whether debug mode is on
+]]
+function DebugLib:new(on)
+    local newObj = {
+    	on = on,
+    }
+    self.__index = self
+    return setmetatable(newObj, self)
+end
+
+--[[
+ * Log message if debug is on
+ * 
+ * @var string message - Message to log
+]]
+function DebugLib:log(message)
+    if (self.on) then
+        log(message)
+    end
+end
+
+--[[
+ * Log message if debug is on AND the given condition is true
+ * 
+ * @var boolean condition - Condition required to be true for the message to log
+ * @var string message - Message to log
+]]
+function DebugLib:logIf(condition, message)
+    if (self.on and condition) then
+        log(message)
+    end
+end


### PR DESCRIPTION
This PR adds a debug library for LogicMachine.

Debug library enables to log messages only when debug mode is activated. This will prevent cluttering the log when script is normal (production) mode, but easily enables one to view log messages when developing or debugging.

API:

```lua
Debug:log(message)
Debug:logIf(condition, message)
```
