### PR TITLE
`Remove logs` library

### DIFF
--- a/RemoveLogs/README.md
+++ b/RemoveLogs/README.md
@@ -27,6 +27,16 @@ LogRemover:deleteScriptErrors("Script #1")
 
 -- Delete alert records from a single script.
 LogRemover:deleteScriptAlerts("Script #1")
+
+-- Delete log records (excluding error and alert) that contain a specific phrase or word
+LogRemover:deleteLogsWithPhrases({"Some log message", "Delete log that contain this"})
+
+-- Delete error records that contain a specific phrase or word
+-- You can pass just one phrase by putting it inside a table
+LogRemover:deleteErrorsWithPhrases({"trigger"})
+
+-- Delete alert records that contain a specific phrase or word
+LogRemover:deleteAlertsWithPhrases({"content"})
 ```
 
 ### Installation

--- a/RemoveLogs/README.md
+++ b/RemoveLogs/README.md
@@ -1,0 +1,38 @@
+# Remove Logs
+Script library that provides convenience methods for deleting log, alert and error records from specified scripts.
+
+Could prove valuable when you want to declutter the log from noisy scripts while keeping other records.
+
+### Usage
+```lua
+require 'user.remove_logs'
+
+-- Remove all types of log (log, error, alert) records from many scripts.
+LogRemover:removeAllScriptLogTypes({"Script #1", "Script #2"})
+
+-- Delete log records (excluding error and alert) from many scripts.
+LogRemover:deleteManyScriptLogs({"Script #1", "Script #2"})
+
+-- Delete error records from many scripts.
+LogRemover:deleteManyScriptErrors({"Script #1", "Script #2"})
+
+-- Delete alert records from many scripts.
+LogRemover:deleteManyScriptAlerts({"Script #1", "Script #2"})
+
+-- Delete log records (excluding error and alert) from a single script.
+LogRemover:deleteScriptLogs("Script #1")
+
+-- Delete error records from a single script.
+LogRemover:deleteScriptErrors("Script #1")
+
+-- Delete alert records from a single script.
+LogRemover:deleteScriptAlerts("Script #1")
+```
+
+### Installation
+1. Copy contents from [user.remove_logs.lua](RemoveLogs/user.remove_logs.lua)
+2. Add new library in user libraries in the scripting section of LogicMachine
+3. Name that library `user.remove_logs`. You might add the description taken from the top of this page if you want.
+4. Open the newly created library file and paste the contents
+5. Save and close
+6. Go to `Usage` above for how to use it.

--- a/RemoveLogs/user.remove_logs.lua
+++ b/RemoveLogs/user.remove_logs.lua
@@ -1,0 +1,133 @@
+--[[
+ * Author: Alexander Volle <knx@avolle.com>
+ * Created: 2023.07.22
+ * Updated: Never
+ * 
+ * Log remover class for removing logs, errors and alerts from the LogicMachine database.
+ * Enables you to remove the clutter from these log types without removing important information.
+ *
+ * There's methods for removing all types of logs (log, alert, error) from specific script names,
+ * or specific types from specific script names.
+ * There's also methods for removing log (including alert and error) that contains
+ * specific words or phrases.
+]]
+
+-- Init object
+LogRemover = {}
+
+--[[
+ * Remove all log records, including errors and alerts that were made from specific scripts.
+ * 
+ * @param table scriptNames - A table of scripts to remove logs, errors and alerts for
+ * @return int - Number of affected rows (deleted logs, errors and alerts)
+]]
+function LogRemover:removeAllScriptLogTypes(scriptNames)
+    local isTable = type(scriptNames) == 'table'
+    assert(isTable, 'Parameter `scriptNames` must be table')
+    local affected = 0
+    for _, script in ipairs(scriptNames) do
+        affected = affected + self:deleteScriptLogs(script)
+        affected = affected + self:deleteScriptErrors(script)
+        affected = affected + self:deleteScriptAlerts(script)
+    end
+    
+    return affected
+end
+
+--[[
+ * Remove only log records that were made from specific scripts.
+ * 
+ * @param table scriptNames - A table of scripts to remove logs for
+ * @return int - Number of affected rows (deleted logs)
+]]
+function LogRemover:deleteManyScriptLogs(scriptNames)
+    local isTable = type(scriptNames) == 'table'
+    assert(isTable, 'Parameter `scriptNames` must be table')
+    local affected = 0
+    for _, script in ipairs(scriptNames) do
+        affected = affected + self:deleteScriptLogs(script)
+    end
+    
+    return affected
+end
+
+--[[
+ * Remove only error records that were made from specific scripts.
+ * 
+ * @param table scriptNames - A table of scripts to remove errors for
+ * @return int - Number of affected rows (deleted errors)
+]]
+function LogRemover:deleteManyScriptErrors(scriptNames)
+    local isTable = type(scriptNames) == 'table'
+    assert(isTable, 'Parameter `scriptNames` must be table')
+    local affected = 0
+    for _, script in ipairs(scriptNames) do
+        affected = affected + self:deleteScriptErrors(script)
+    end
+    
+    return affected
+end
+
+--[[
+ * Remove only alert records that were made from specific scripts.
+ * 
+ * @param table scriptNames - A table of scripts to remove alerts for
+ * @return int - Number of affected rows (deleted alerts)
+]]
+function LogRemover:deleteManyScriptAlerts(scriptNames)
+    local isTable = type(scriptNames) == 'table'
+    assert(isTable, 'Parameter `scriptNames` must be table')
+    local affected = 0
+    for _, script in ipairs(scriptNames) do
+        affected = affected + self:deleteScriptAlerts(script)
+    end
+    
+    return affected
+end
+
+--[[
+ * Remove only log records that were made from a specific script.
+ * 
+ * @param string scriptName - String of script to remove logs for
+ * @return int - Number of affected rows (deleted logs)
+]]
+function LogRemover:deleteScriptLogs(scriptName)
+    return self:_deleteScriptLog('logs', scriptName)
+end
+
+--[[
+ * Remove only error records that were made from a specific script.
+ * 
+ * @param string scriptName - String of script to remove errors for
+ * @return int - Number of affected rows (deleted errors)
+]]
+function LogRemover:deleteScriptErrors(scriptName)
+    return self:_deleteScriptLog('errors', scriptName)
+end
+
+--[[
+ * Remove only alert records that were made from a specific script.
+ * 
+ * @param string scriptName - String of script to remove alerts for
+ * @return int - Number of affected rows (deleted alerts)
+]]
+function LogRemover:deleteScriptAlerts(scriptName)
+    return self:_deleteScriptLog('alerts', scriptName)
+end
+
+--[[
+ * INTERNAL FUNCTION: Remove certain logtype with certain script name
+ * 
+ * @param string logType - Either log, alert or errors
+ * @param string scriptName - String of script to remove log type for
+ * @return int - Number of affected rows (deleted log types)
+]]
+function LogRemover:_deleteScriptLog(logType, scriptName)
+    assert(
+        logType == 'logs' or logType == 'alerts' or logType == 'errors', 
+        'Log type must be one of these: logs, alerts, errors'
+    )
+    assert(type(scriptName) == 'string', 'Parameter `scriptName` must be string')
+    
+    return db:query("DELETE FROM ? WHERE scriptname = ?", logType, scriptName)
+end


### PR DESCRIPTION
# Remove Logs
Script library that provides convenience methods for deleting log, alert and error records from specified scripts.

You can also delete log records that contain one or multiple phrases.

Could prove valuable when you want to declutter the log from noisy scripts while keeping other records.